### PR TITLE
from zidv to xarray

### DIFF
--- a/projects/ipython-IDV/ipython-IDV/drilsdown.py
+++ b/projects/ipython-IDV/ipython-IDV/drilsdown.py
@@ -46,6 +46,8 @@ from os.path import isfile, join
 import IPython 
 from IPython.lib import kernel
 import shlex
+from io import BytesIO
+from zipfile import ZipFile
 
 try:
     from urllib.request import urlopen
@@ -77,7 +79,7 @@ try:
         if fileorurl.startswith('http'):
             zfile = request.urlopen(fileorurl)
             zfile = BytesIO(zfile.read())
-        elif os.path.exists(fileorurl):
+        elif isfile(fileorurl):
             zfile=fileorurl
         else:
             return 'Unknown File or Url'

--- a/projects/ipython-IDV/ipython-IDV/drilsdown.py
+++ b/projects/ipython-IDV/ipython-IDV/drilsdown.py
@@ -73,11 +73,11 @@ try:
     xarray.Dataset.to_IDV=to_IDV
 
     def from_zidv(fileorurl=None,outdir=None):
-    """ Loading data from IDV zip file '.zidv' as xarray Dataset
+        """Loading data from IDV zip file '.zidv' as xarray Dataset
         fileorurl can be a local .zidv file or a remote url.
         Optionally, outdir can be specified where the file is unzipped"""
         if fileorurl.startswith('http'):
-            zfile = request.urlopen(fileorurl)
+            zfile = urlopen(fileorurl)
             zfile = BytesIO(zfile.read())
         elif isfile(fileorurl):
             zfile=fileorurl
@@ -88,12 +88,12 @@ try:
             for contained_file in zip_file.namelist():
                 if str(contained_file).startswith('data'):
                     try:
-                        das.append(xr.open_dataset(zip_file.extract(contained_file,outdir)))
+                        das.append(xarray.open_dataset(zip_file.extract(contained_file,outdir)))
                     except Exception as err:
                         print('Skipping file '+str(contained_file)+' because of error '+err)
-        return xr.merge(das)
+        return xarray.merge(das)
 
-    xr.from_zidv=from_zidv 
+    xarray.from_zidv=from_zidv 
 
 
 except ImportError:


### PR DESCRIPTION
this commit adds another interface to open data from .zidv files locally or remote url into  a xarray dataset.
> %loadext drilsdown
or
> import drilsdown
 
> import xarray as xr
> xr.from_zidv('http://earthcube.ccs.miami.edu:8080/repository/entry/get/GOM_shredding_event_2006-06-11.zidv?entryid=51b5a9b6-061c-4a50-a397-ec0aa67f81eb')
 or 
> xr.from_xidv('/path/to/localfile.zidv')