### PR TITLE
fix install issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ deploy:
   skip_cleanup: true
   local_dir: docs/_build/html
   github_token: $GITHUB_TOKEN
-target_branch: gh-pages
-committer-from-gh: true
+  target_branch: gh-pages
+  committer-from-gh: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
 -   ./ci/update_docs.sh
 deploy:
   provider: pages
+  on:
+    tags: true # only for tagged commits
   skip_cleanup: true
   local_dir: docs/_build/html
   github_token: $GITHUB_TOKEN

--- a/projects/ipython_IDV/setup.py
+++ b/projects/ipython_IDV/setup.py
@@ -20,9 +20,10 @@ setuptools.setup(
     long_description=open('README.md').read(),
     packages = setuptools.find_packages(),
     py_modules = ['ipython_IDV'],
-    install_requires=['ipython'],
+    install_requires=['ipython','ipywidgets','requests'],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
+        'Framework :: IPython',    
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,6 @@ setup(
     },
     extras_require={
         'addons': ['numpy','netcdf4','xarray','metpy'],
-        'visual': ['pyviz'],
+        'visual': ['pyviz','geoviews'],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ SOURCES = {
    'idv_teleport': 'projects/IDV_teleport',
    'ramadda_publish': 'projects/RAMADDA_publish',
 }
-VERSION = '2.4.9'
+VERSION = '2.4.91'
 
 def install_drilsdown_projects(sources, develop=False):
     """ Use pip to install all drilsdown projects.  """
@@ -52,6 +52,8 @@ setup(
     author="Drilsdown team",
     author_email="drilsdown@unidata.ucar.edu",
     description="A collection of tools for jupyter notebooks",
+    long_description_content_type='text/markdown',
+    long_description=open('README.md').read(),
     url="https://github.com/Unidata/drilsdown",
     license="MIT",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ import subprocess
 
 PACKAGE_NAME = 'drilsdown'
 SOURCES = {
-    'ipython_IDV': 'projects/ipython_IDV',
-#   'idv_teleport': 'projects/IDV_teleport',
-#   'ramadda_publish': 'projects/RAMADDA_publish',
+   'ipython_IDV': 'projects/ipython_IDV',
+   'idv_teleport': 'projects/IDV_teleport',
+   'ramadda_publish': 'projects/RAMADDA_publish',
 }
 VERSION = '2.4.9'
 
@@ -22,9 +22,9 @@ def install_drilsdown_projects(sources, develop=False):
         try:
             os.chdir(os.path.join(wd, v))
             if develop:
-                subprocess.check_call(['pip', 'install', '-e', '.'])
+                subprocess.check_call(['pip', 'install', '-e', '.']) # could be pip3 on certain platforms
             else:
-                subprocess.check_call(['pip', 'install', '.'])
+                subprocess.check_call(['pip', 'install', '.']) # could be pip3 on certain platforms
         except Exception as e:
             print("Oops, something went wrong installing", k)
             print(e)
@@ -67,12 +67,15 @@ setup(
         'ipython',
         'ipywidgets>=7.1.0rc',
         'jupyter-client',
-#        'ipython_IDV>=' + VERSION + "'", # source and a dependency??
-        'ramadda_publish>=1.3',
-        'idv_teleport>=1.6',
+#        'ipython_IDV>=' + VERSION + "'", # cannot be source and a dependency??
+        'ipython-IDV', # from pypi
+        'ramadda_publish', #from pypi
+        'idv_teleport', #from pypi
     ],
     cmdclass={
-        'install': InstallCmd,
+        #'install': InstallCmd, # do not overwrite for now to make 
+                                # pip install and python setup.py install do same.
+                                # note in class pip might be called pip3 on certain platforms
         'develop': DevelopCmd,
     },
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ import subprocess
 PACKAGE_NAME = 'drilsdown'
 SOURCES = {
     'ipython_IDV': 'projects/ipython_IDV',
-    'idv_teleport': 'projects/IDV_teleport/bin',
-    'ramadda_publish': 'projects/RAMADDA_publish/bin',
+#   'idv_teleport': 'projects/IDV_teleport',
+#   'ramadda_publish': 'projects/RAMADDA_publish',
 }
-VERSION = '2.4.8'
+VERSION = '2.4.9'
 
 def install_drilsdown_projects(sources, develop=False):
     """ Use pip to install all drilsdown projects.  """
@@ -63,22 +63,20 @@ setup(
     install_requires=[
         'future',
         'six',
-        'ipython_IDV>=' + VERSION + "'",
+        'requests',
+        'ipython',
+        'ipywidgets>=7.1.0rc',
+        'jupyter-client',
+#        'ipython_IDV>=' + VERSION + "'", # source and a dependency??
         'ramadda_publish>=1.3',
         'idv_teleport>=1.6',
-        'ipykernel',
-        'jupyter-client',
-        'ipywidgets>=7.1.0rc',
-        'pyviz',
-        'xarray',
-        'holoviews',
-        'cartopy',
-        'geoviews',
-        'MetPy'    
     ],
     cmdclass={
         'install': InstallCmd,
         'develop': DevelopCmd,
     },
-
+    extras_require={
+        'addons': ['numpy','netcdf4','xarray','metpy'],
+        'visual': ['pyviz'],
+    }
 )


### PR DESCRIPTION
- add proper dependencies for ipython-IDV ( requests, ipython, ipywidgets) 
- add pyviz, geoviews as optional dependency, cartopy install often fails from pip
- disable installCmd to make pip and python setup.py install mean same, pip might not be available on all platforms
- make sources (ipython-IDV, ramadda_publish, idv_teleport) install from pip 
