### PR TITLE
fix failing doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,22 @@
 language: python
 python:
--   '3.6'
-before_install:
-- sudo apt-get install -y pandoc
-- travis_retry pip install --upgrade pip
-- travis_retry pip install ipython
-- travis_retry pip install ipywidgets
-- travis_retry pip install requests
+  - '3.6' # add more versions
 install:
-- travis_retry pip install --upgrade pip
-- travis_retry pip install tox
-- travis_retry pip install sphinx
-- travis_retry pip install sphinx_rtd_theme
+  - sudo apt-get install -y pandoc
+  - travis_retry pip install --upgrade pip
+  - travis_retry pip install ipython
+  - travis_retry pip install ipywidgets
+  - travis_retry pip install requests
+  - travis_retry pip install tox
 script:
--   ./ci/run_tests.sh
--   ./ci/update_docs.sh
+  - ./ci/run_tests.sh
+  - ./ci/update_docs.sh # keep this so that example notebooks are executed on every commit
 deploy:
-  provider: pages
-  on:
-    tags: true # only for tagged commits
-  skip_cleanup: true
-  local_dir: docs/_build/html
-  github_token: $GITHUB_TOKEN
-  target_branch: gh-pages
-  committer-from-gh: true
+  - provider: pages
+    skip_cleanup: true
+    on:
+      tags: true # do not update documentation unless it is a tagged commit
+    local_dir: docs/_build/html
+    github_token: $GITHUB_TOKEN
+    target_branch: gh-pages
+    committer-from-gh: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
 ipykernel
 ipywidgets>=7.1.0rc1
 jupyter_client
-jupyter_sphinx
+jupyter_sphinx==0.1.2
 nbsphinx>=0.2.13
-recommonmark==0.4.0
+recommonmark>=0.4.0
 sphinx>=1.4.6
 sphinx_rtd_theme
-pandoc
 #pyviz


### PR DESCRIPTION
- fix failing doctests by using older version of jupyter_sphinx. at some point we need to re adapt the doc build to the changed api. 

- docs should be build on every commit but documentation page is updated only on a tagged commit.  By this we can check any new uploaded usecase examples work  on atleast travis  but their reqirements can always break. so nothing seems elegant right now.  