### PR TITLE
Removal of Unidata ftp server.

### DIFF
--- a/projects/IDV_teleport/runmetest.sh
+++ b/projects/IDV_teleport/runmetest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-curl -s ftp://ftp.unidata.ucar.edu/pub/idv/nightly_idv_5.5/idv_5_5_linux64_installer.sh>idv.sh
+curl -s https://downloads.unidata.ucar.edu/idv/nightly/idv_6_2u3_linux64_installer.sh>idv.sh
 chmod +x idv.sh
 wrkdir=`pwd`
 printf 'o\n\n1\n'`pwd`'/IDV\n'|./idv.sh


### PR DESCRIPTION
Now references the correct location and most current version of the IDV.  Without this change, the script will break.